### PR TITLE
Add CMake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,9 @@ RUN rustup component add rustfmt-preview
 
 RUN cargo install cargo-release
 
+RUN apt-get update && apt-get install -y \
+    cmake \
+&& rm -rf /var/lib/apt/lists/*
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
CMake is often required for native dependencies, e.g. https://github.com/bwasty/vulkan-tutorial-rs/pull/12.